### PR TITLE
Fix try_take_player_blocks

### DIFF
--- a/mbag/environment/mbag_env.py
+++ b/mbag/environment/mbag_env.py
@@ -761,8 +761,8 @@ class MbagEnv(object):
                         left_to_take = 0
                         break
                     else:
-                        player_inventory[slot, 1] = 0
                         left_to_take -= player_inventory[slot, 1]
+                        player_inventory[slot, 1] = 0
                 assert left_to_take == 0
             return True
 


### PR DESCRIPTION
Fixes bug `fix_try_take_player_blocks` where the number of blocks in a given slot is not subtracted from the remaining number of blocks that should be taken.