### PR TITLE
Cast backbone output to float to avoid LSTM error

### DIFF
--- a/mbag/rllib/torch_models.py
+++ b/mbag/rllib/torch_models.py
@@ -690,7 +690,7 @@ class MbagTorchModel(TorchModelV2, nn.Module, ABC):
                     self._backbone_out = backbone(self._backbone_in)
                     if self.use_per_location_lstm:
                         self._backbone_out, state = self._run_lstm(
-                            self._backbone_out, state, seq_lens
+                            self._backbone_out.float(), state, seq_lens
                         )
 
             self._backbone_out_shape = self._backbone_out.size()[1:]


### PR DESCRIPTION
Without casting to `float`, training with a per-location LSTM can result in the following error:

```
  File "/nas/ucb/ebronstein/minecraft-building-assistance-game/mbag/rllib/torch_models.py", line 681, in forward
    self._backbone_out, state = self._run_lstm(
  File "/nas/ucb/ebronstein/minecraft-building-assistance-game/mbag/rllib/torch_models.py", line 568, in _run_lstm
    lstm_out_per_location, state_out_per_location = self.per_location_lstm(
  File "/nas/ucb/ebronstein/anaconda3/envs/mbag/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/nas/ucb/ebronstein/anaconda3/envs/mbag/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/nas/ucb/ebronstein/anaconda3/envs/mbag/lib/python3.8/site-packages/torch/nn/modules/rnn.py", line 879, in forward
    result = _VF.lstm(input, hx, self._flat_weights, self.bias, self.num_layers,
RuntimeError: "_thnn_fused_lstm_cell_cuda" not implemented for 'BFloat16'
```