### PR TITLE
Add weight decay option to config

### DIFF
--- a/mbag/rllib/alpha_zero/alpha_zero_policy.py
+++ b/mbag/rllib/alpha_zero/alpha_zero_policy.py
@@ -32,7 +32,12 @@ from mbag.environment.types import CURRENT_BLOCKS, GOAL_BLOCKS, MbagInfoDict, Wo
 
 from ..kl_regularization import ANCHOR_POLICY_ACTION_DIST_INPUTS
 from ..rllib_env import unwrap_mbag_env
-from ..torch_models import ACTION_MASK, MbagTorchModel, OtherAgentActionPredictorMixin
+from ..torch_models import (
+    ACTION_MASK,
+    MbagTorchModel,
+    OptimizerMixin,
+    OtherAgentActionPredictorMixin,
+)
 from .mcts import MbagMCTS, MbagMCTSNode, MbagRootParentNode
 from .planning import MbagEnvModel
 
@@ -51,7 +56,9 @@ PREV_C_PUCT = "prev_c_puct"
 logger = logging.getLogger(__name__)
 
 
-class MbagAlphaZeroPolicy(EntropyCoeffSchedule, LearningRateSchedule, AlphaZeroPolicy):
+class MbagAlphaZeroPolicy(
+    EntropyCoeffSchedule, LearningRateSchedule, OptimizerMixin, AlphaZeroPolicy
+):
     mcts: MbagMCTS
     envs: List[MbagEnvModel]
     config: Dict[str, Any]

--- a/mbag/rllib/bc.py
+++ b/mbag/rllib/bc.py
@@ -49,7 +49,7 @@ from ray.tune.registry import register_trainable
 from torch import nn
 
 from .human_data import PARTICIPANT_ID
-from .torch_models import MbagTorchModel
+from .torch_models import MbagTorchModel, OptimizerMixin
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ class BCTorchLossesAndStats(NamedTuple):
     vf_explained_var: torch.Tensor
 
 
-class BCTorchPolicy(LearningRateSchedule, TorchPolicy):
+class BCTorchPolicy(LearningRateSchedule, OptimizerMixin, TorchPolicy):
     def __init__(self, observation_space, action_space, config):
         TorchPolicy.__init__(
             self,

--- a/mbag/rllib/gail.py
+++ b/mbag/rllib/gail.py
@@ -48,7 +48,7 @@ from ray.util.debug import log_once
 from torch import nn
 
 from .bc import BC
-from .torch_models import MbagTorchModel, ModelWithDiscriminator
+from .torch_models import MbagTorchModel, ModelWithDiscriminator, OptimizerMixinV2
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 IS_DEMONSTRATION = "is_demonstration"
 
 
-class MbagGAILTorchPolicy(PPOTorchPolicy):
+class MbagGAILTorchPolicy(OptimizerMixinV2, PPOTorchPolicy):
     def __init__(self, observation_space, action_space, config):
         PPOTorchPolicy.__init__(
             self,

--- a/mbag/rllib/ppo.py
+++ b/mbag/rllib/ppo.py
@@ -41,12 +41,12 @@ from .torch_action_distributions import (
     MbagAutoregressiveActionDistribution,
     MbagBilevelCategorical,
 )
-from .torch_models import ACTION_MASK, MbagTorchModel
+from .torch_models import ACTION_MASK, MbagTorchModel, OptimizerMixinV2
 
 logger = logging.getLogger(__name__)
 
 
-class MbagPPOTorchPolicy(PPOTorchPolicy):
+class MbagPPOTorchPolicy(OptimizerMixinV2, PPOTorchPolicy):
     config: Dict[str, Any]
 
     def __init__(

--- a/mbag/rllib/torch_models.py
+++ b/mbag/rllib/torch_models.py
@@ -25,10 +25,13 @@ from ray.rllib.models.preprocessors import get_preprocessor
 from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
 from ray.rllib.policy.rnn_sequencing import add_time_dimension
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.torch_policy import TorchPolicy
+from ray.rllib.policy.torch_policy_v2 import TorchPolicyV2
 from ray.rllib.policy.view_requirement import ViewRequirement
+from ray.rllib.utils.exploration.exploration import Exploration
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.torch_utils import convert_to_torch_tensor
-from ray.rllib.utils.typing import TensorType
+from ray.rllib.utils.typing import AlgorithmConfigDict, TensorType
 from torch import nn
 from typing_extensions import TypedDict
 
@@ -1895,3 +1898,73 @@ class MbagTransformerModelWithDiscriminator(MbagTransformerModel, DiscriminatorM
 ModelCatalog.register_custom_model(
     "mbag_transformer_with_discriminator_model", MbagTransformerModelWithDiscriminator
 )
+
+
+def _optimizer(
+    config: Optional[AlgorithmConfigDict],
+    model: Optional[TorchModelV2],
+    exploration: Optional[Exploration],
+) -> Union[List[torch.optim.Optimizer], torch.optim.Optimizer]:
+    """Customize the local PyTorch optimizer(s) to use.
+
+    Args:
+        config: The Policy's config dict.
+        model: PyTorch policy module. Given observations as
+            input, this module must return a list of outputs where the
+            first item is action logits, and the rest can be any value.
+        exploration: The Policy's exploration strategy.
+
+    Returns:
+        The local PyTorch optimizer(s) to use for this Policy.
+
+    Raises:
+        ValueError: If the model is None.
+        ValueError: If the model does not inherit from torch.nn.Module.
+    """
+    if model is None:
+        raise ValueError("Model is required to create optimizer.")
+    if not isinstance(model, nn.Module):
+        raise ValueError(
+            "Model must be an instance of torch.nn.Module to create optimizer."
+        )
+    module = cast(nn.Module, model)
+
+    if config is not None:
+        optimizer: torch.optim.Optimizer = torch.optim.Adam(
+            module.parameters(),
+            lr=config["lr"],
+            **config.get("optimizer", {}),
+        )
+    else:
+        optimizer = torch.optim.Adam(module.parameters())
+    optimizers = [optimizer]
+    if exploration:
+        optimizers = exploration.get_exploration_optimizer(optimizers)
+
+    return optimizers
+
+
+class OptimizerMixin(TorchPolicy):
+
+    def optimizer(
+        self,
+    ) -> Union[List[torch.optim.Optimizer], torch.optim.Optimizer]:
+        """Customize the local PyTorch optimizer(s) to use.
+
+        Returns:
+            The local PyTorch optimizer(s) to use for this Policy.
+        """
+        return _optimizer(getattr(self, "config", None), self.model, self.exploration)
+
+
+class OptimizerMixinV2(TorchPolicyV2):
+
+    def optimizer(
+        self,
+    ) -> Union[List[torch.optim.Optimizer], torch.optim.Optimizer]:
+        """Customize the local PyTorch optimizer(s) to use.
+
+        Returns:
+            The local PyTorch optimizer(s) to use for this Policy.
+        """
+        return _optimizer(getattr(self, "config", None), self.model, self.exploration)

--- a/mbag/scripts/train.py
+++ b/mbag/scripts/train.py
@@ -301,6 +301,7 @@ def sacred_config(_log):  # noqa
     num_training_iters = 500  # noqa: F841
     lr = 1e-3
     lr_schedule = None
+    weight_decay = 0
     grad_clip = 10
     gamma = 0.95
     gae_lambda = 0.98
@@ -665,6 +666,7 @@ def sacred_config(_log):  # noqa
     )
     config.rl_module(_enable_rl_module_api=False)
     config.training(
+        optimizer=dict(weight_decay=weight_decay),
         _enable_learner_api=False,
     )
     config.simple_optimizer = simple_optimizer


### PR DESCRIPTION
This PR adds a `weight_decay` option to the config and integrates it with the existing policy classes.

Although the rllib docs for [AlgorithmConfig.training](https://docs.ray.io/en/latest/rllib/package_ref/doc/ray.rllib.algorithms.algorithm_config.AlgorithmConfig.training.html#ray.rllib.algorithms.algorithm_config.AlgorithmConfig.training) say that there is an `optimizer` argument that takes in a dictionary to customize the optimizer, it does not seem to be used when initializing the optimizer, which happens in `TorchPolicy.optimizer` and `TorchPolicyV2.optimizer`. I made `OptimizerMixin` and `OptimizerMixinV2` classes that create the Adam optimizer using the training optimizer config. Now, the BC, PPO, GAIL, and AlphaZero classes inherit from these mix-ins, depending on whether they currently inherit from `TorchPolicy` or `TorchPolicyV2`.